### PR TITLE
getinfo: Update to set paytxfee to 0.01

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -92,7 +92,7 @@ CScript COINBASE_FLAGS;
 const string strMessageMagic = "Sigil Signed Message:\n";
 
 // Settings
-int64 nTransactionFee = 0.01;
+int64 nTransactionFee = MIN_TX_FEE;
 int64 nMinimumInputValue = TX_DUST;
 int64 nStakeMinValue = 1 * COIN;
 


### PR DESCRIPTION
On mining pools with low minimum payouts, all payments below 0.01 failed.

Work-Around: If a min payout of 0.01 is set manually for the coin or the mining pool, payments works fine. This work-around is not needed anymore if this pull request is accepted.

I analysed and compared the code of TZC and SGL, I found this difference related to calculation of paytxfee. As TZC payments are working fine despite other wallet problems.

Remark: I don't think that this change will solve the problems described by ocminer in issue #1 but payments will be possible without work-around.